### PR TITLE
Some minor fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = function(dockerFile){
 
-	var arrayFields = ['add', 'expose', 'volume', 'run']
+        var arrayFields = ['add', 'expose', 'volume', 'run', 'workdir']
 	var arrayFieldMap = {}
 	var filters = {
 		add:function(val){
@@ -26,10 +26,16 @@ module.exports = function(dockerFile){
 		arrayFieldMap[f] = true
 	})
 
+        dockerFile = dockerFile.replace(/\\\n/g, '')
 	var lines = dockerFile.split(/\r?\n/) || []
 
 	lines.forEach(function(line){
 		var cmd = null
+
+                if (!line.trim() || line[0] === '#') {
+                        return
+                }
+
 		line = line.replace(/^\w+ /, function(command){
 			cmd = command.replace(/\s+/, '').toLowerCase()
 			return ''

--- a/test/Dockerfile2
+++ b/test/Dockerfile2
@@ -1,0 +1,18 @@
+FROM ubuntu:14.04
+WORKDIR /
+RUN apt-get update && apt-get install -y \
+    aufs-tools \
+    automake \
+    build-essential \
+    curl \
+    dpkg-sig \
+    libcap-dev \
+    libsqlite3-dev \
+    mercurial \
+    reprepro \
+    ruby1.9.1 \
+    ruby1.9.1-dev \
+    s3cmd=1.1.* \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /home
+CMD [bash]

--- a/test/parser.js
+++ b/test/parser.js
@@ -28,8 +28,30 @@ tape('should parse a Dockerfile', function (t) {
       VAR4:'20'
     },
     from:'quarry/monnode',
-    workdir:'/srv/app',
+    workdir:['/srv/app'],
     entrypoint:'node index.js'
+  }
+
+  t.deepEqual(pojo, wanted)
+
+  t.end()
+  
+})
+
+tape('should parse a Dockerfile with line escapes', function (t) {
+
+  var dockerFile = fs.readFileSync(__dirname + '/Dockerfile2', 'utf8')
+  var pojo = parse(dockerFile)
+  var wanted = {
+    add:[],
+    cmd:'[bash]',
+    expose:[],
+    volume:[],
+    run:[
+      'apt-get update && apt-get install -y     aufs-tools     automake     build-essential     curl     dpkg-sig     libcap-dev     libsqlite3-dev     mercurial     reprepro     ruby1.9.1     ruby1.9.1-dev     s3cmd=1.1.*  && rm -rf /var/lib/apt/lists/*'
+    ],
+    from:'ubuntu:14.04',
+    workdir:['/', '/home'],
   }
 
   t.deepEqual(pojo, wanted)


### PR DESCRIPTION
There can be multiple WORKDIR commands in a docker file.
Added support for dealing with -escaped line breaks.
Added an early bailout check for comments and empty lines.
